### PR TITLE
[~] changed wiki/documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A Python Module for the [Bubblez.app](https://bubblez.app) api
 ## Version's 
 - Python: This one..
 - Nodejs: [HERE](https://github.com/ProjectBubblez/bubblez.js)
+- Nodejs Wiki/Documentation: [Wiki/Documentation](https://github.com/ProjectBubblez/bubblez.js/blob/master/DOCUMENTATION.md)
  ---- 
-- Official Wiki/Documentation: [Wiki/Documentation](https://github.com/ProjectBubblez/bubblez.js/blob/master/DOCUMENTATION.md)
 - Website: [Bubblez.app](https://bubblez.app)
 
 ## Setup


### PR DESCRIPTION
The bubblez API doesn't have an official documentation site yet and is only accessible from the discord server